### PR TITLE
Added support for T2T downsampling

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,6 @@ To use these scripts, follow the steps below:
 
 4. **downsampleReference.pl**: This Perl script downsamples a reference genome FASTA file by removing all other chromosomes except the specified one. Usage: `./downsampleReference.pl GRCh38.d1.vd1.fa chr > GRCh38.d1.vd1.chr22.fa`
 
-4. **downsampleReference_T2T.pl**: This Perl script has same function as **downsampleReference.pl** and is suitable for downsampling T2T FASTA file. Usage: `./downsampleReference.pl GRCh38.d1.vd1.fa chr > GRCh38.d1.vd1.chr22.fa`
+5. **downsampleReference_T2T.pl**: This Perl script has same function as **downsampleReference.pl** and is suitable for downsampling T2T FASTA file. Usage: `./downsampleReference.pl GRCh38.d1.vd1.fa chr > GRCh38.d1.vd1.chr22.fa`
 
 Remember to replace the input file names and chromosome names with your own data and desired chromosome.

--- a/README.md
+++ b/README.md
@@ -31,4 +31,6 @@ To use these scripts, follow the steps below:
 
 4. **downsampleReference.pl**: This Perl script downsamples a reference genome FASTA file by removing all other chromosomes except the specified one. Usage: `./downsampleReference.pl GRCh38.d1.vd1.fa chr > GRCh38.d1.vd1.chr22.fa`
 
+4. **downsampleReference_T2T.pl**: This Perl script has same function as **downsampleReference.pl** and is suitable for downsampling T2T FASTA file. Usage: `./downsampleReference.pl GRCh38.d1.vd1.fa chr > GRCh38.d1.vd1.chr22.fa`
+
 Remember to replace the input file names and chromosome names with your own data and desired chromosome.

--- a/downsampleReference_T2T.pl
+++ b/downsampleReference_T2T.pl
@@ -1,0 +1,19 @@
+#!/usr/bin/perl
+#usage ./downsampleReference.pl GRCh38.d1.vd1.fa chr22 > GRCh38.d1.vd1.chr22.fa
+
+my ($reference, $chr) = @ARGV;
+open (IN, $reference) || die;
+my $printFlag = 0;
+while (defined(my $line = <IN>)) {
+    if (substr($line, 0, 1) eq ">") {
+        if (index($line, $chr) != -1) {
+            $printFlag = 1;
+        } else {
+            $printFlag = 0;
+        }
+    }
+    if($printFlag) {
+        print "$line";
+    }
+}
+


### PR DESCRIPTION
Since the naming scheme of chr22 in T2T is different from GRCh38, a new downsampleReference_T2T.pl file was added to downsample the FASTA file of T2T. 
Also the readme file has been added with additional instructions.